### PR TITLE
Switch Renovate yarn dedupe strategy to fewer

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   ],
   "prConcurrentLimit": 20,
   "postUpdateOptions": [
-    "yarnDedupeHighest"
+    "yarnDedupeFewer"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Use `yarnDedupeFewer` instead of `yarnDedupeHighest` so Renovate runs
`yarn dedupe --strategy fewer` after dependency updates, minimizing the
number of distinct package versions in yarn.lock.

https://claude.ai/code/session_0151dzAo5YgmcNtMsDZUj79d