### PR TITLE
Restrict @backstage/* packages to patch updates only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,16 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": [
+        "@backstage/**"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "enabled": false
+    },
+    {
       "groupName": "acr plugin",
       "groupSlug": "acr",
       "matchPackageNames": [


### PR DESCRIPTION
Add a Renovate package rule that disables major and minor updates for
all @backstage/* dependencies so only patch versions are picked up.